### PR TITLE
Enhance URI open handler to work on Windows

### DIFF
--- a/autoload/textobj/uri.vim
+++ b/autoload/textobj/uri.vim
@@ -36,7 +36,9 @@ let g:textobj_uri_patterns = {
 let g:textobj_uri_search_timeout = 100
 
 function! TextobjUriOpen()
-    if executable('open-cli')
+    if has('win32')
+        silent! call system(printf('start /b explorer %s', shellescape(g:textobj_uri)))
+    elseif executable('open-cli')
         silent! call system(printf('%s %s &', 'open-cli', shellescape(g:textobj_uri)))
     elseif executable('xdg-open')
         silent! call system(printf('%s %s &', 'xdg-open', shellescape(g:textobj_uri)))


### PR DESCRIPTION
I use this plugin on Windows 10 and Linux with both vim and neovim, and see that the URI handler function TextobjUriOpen(), mapped to 'go' by default, does not work on Windows.  I first wrote a wrapper script xdg-open.cmd to work around this limitation, but the script only works with neovim on Windows, not vim on Windows.  This pull request fixes the limitation by running the command 'start /b explorer <URL>' when running on Windows, rather than 'xdg-open' or the other alternatives.  It works with both vim and neovim, and makes any wrapper script on Windows unnecessary.
